### PR TITLE
fix: prevent returning empty strings for list

### DIFF
--- a/store/memory.go
+++ b/store/memory.go
@@ -121,29 +121,27 @@ func (m *memoryStore) delete(prefix, key string) {
 
 func (m *memoryStore) list(prefix string, limit, offset uint) []string {
 	allItems := m.store.Items()
-	allKeys := make([]string, len(allItems))
-	i := 0
+	foundKeys := make([]string, 0, len(allItems))
 
 	for k := range allItems {
 		if !strings.HasPrefix(k, prefix+"/") {
 			continue
 		}
-		allKeys[i] = strings.TrimPrefix(k, prefix+"/")
-		i++
+		foundKeys = append(foundKeys, strings.TrimPrefix(k, prefix+"/"))
 	}
 
 	if limit != 0 || offset != 0 {
-		sort.Slice(allKeys, func(i, j int) bool { return allKeys[i] < allKeys[j] })
+		sort.Slice(foundKeys, func(i, j int) bool { return foundKeys[i] < foundKeys[j] })
 		min := func(i, j uint) uint {
 			if i < j {
 				return i
 			}
 			return j
 		}
-		return allKeys[offset:min(limit, uint(len(allKeys)))]
+		return foundKeys[offset:min(limit, uint(len(foundKeys)))]
 	}
 
-	return allKeys
+	return foundKeys
 }
 
 func (m *memoryStore) Close() error {


### PR DESCRIPTION
Fix memory store list returning empty strings along with the found keys